### PR TITLE
日記ページに前後ナビゲーションを追加

### DIFF
--- a/src/layouts/DailyBase.astro
+++ b/src/layouts/DailyBase.astro
@@ -1,5 +1,6 @@
 ---
 import Base from "./Base.astro";
+import { getCollection } from "astro:content";
 
 import "../styles/blog.css";
 const { post } = Astro.props;
@@ -16,6 +17,23 @@ const year = parts[0];
 const month = parts[1];
 const filename = parts[2].replace('.mdx', '');
 const ogImage = `${import.meta.env.SITE}/daily/${year}/${month}/${filename}.png`;
+
+// Get previous and next posts for navigation
+const allPosts = await getCollection("daily");
+const sortedPosts = allPosts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+const currentIndex = sortedPosts.findIndex(p => p.id === post.id);
+const prevPost = currentIndex < sortedPosts.length - 1 ? sortedPosts[currentIndex + 1] : null;
+const nextPost = currentIndex > 0 ? sortedPosts[currentIndex - 1] : null;
+
+// Create URLs for navigation links
+const getPostUrl = (post) => {
+  if (!post) return null;
+  const postParts = post.id.split('/');
+  return `/daily/${postParts[0]}/${postParts[1]}/${postParts[2].replace('.mdx', '')}`;
+};
+
+const prevUrl = prevPost ? getPostUrl(prevPost) : null;
+const nextUrl = nextPost ? getPostUrl(nextPost) : null;
 ---
 
 <Fragment slot="head">
@@ -33,6 +51,21 @@ const ogImage = `${import.meta.env.SITE}/daily/${year}/${month}/${filename}.png`
 		<h1><time datetime={pubDate}>{formattedDate}</time>の日記</h1>
 		<slot />
 	</article>
+
+	<nav class="daily-nav">
+		<div class="nav-links">
+			{prevUrl && (
+				<a href={prevUrl} class="nav-link prev">
+					前の日記
+				</a>
+			)}
+			{nextUrl && (
+				<a href={nextUrl} class="nav-link next">
+					次の日記
+				</a>
+			)}
+		</div>
+	</nav>
 </Base>
 
 <style>
@@ -55,5 +88,39 @@ const ogImage = `${import.meta.env.SITE}/daily/${year}/${month}/${filename}.png`
 
 		animation: grow-progress linear;
 		animation-timeline: scroll();
+	}
+
+	.daily-nav {
+		margin: var(--space-l) 0;
+	}
+
+	.nav-links {
+		display: flex;
+		justify-content: space-between;
+		width: 100%;
+	}
+
+	.nav-link {
+		display: inline-block;
+		padding: var(--space-xxs) var(--space-xs);
+		border: 1px solid var(--gray);
+		border-radius: 4px;
+		color: var(--color);
+		font-size: 0.9rem;
+		text-decoration: none !important;
+		transition: all 0.2s ease;
+	}
+
+	.nav-link:hover {
+		border-color: var(--accent2);
+		color: var(--accent2);
+	}
+
+	.nav-link.prev {
+		margin-right: auto;
+	}
+
+	.nav-link.next {
+		margin-left: auto;
 	}
 </style>


### PR DESCRIPTION
## 概要
日記ページの下部に、前の日記と次の日記へのリンクを追加しました。

## 変更内容
- 日記ページ下部にナビゲーションリンクを追加
- 前後の記事を日付順に取得するロジックを実装
- シンプルで控えめなデザインのナビゲーションボタンを配置

## テスト方法
1. 開発サーバーを起動 (`pnpm dev`)
2. 任意の日記ページを開く
3. ページ下部に前後の日記へのリンクが表示されることを確認
4. リンクをクリックして前後の日記に移動できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added navigation links to move to the previous or next daily post within the layout, making it easier to browse between entries.

- **Style**
  - Introduced new styles for the navigation links to improve visual clarity and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->