### PR TITLE
コードブロックにコピーボタンを追加

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import sitemap from "@astrojs/sitemap";
 import codeBlockPlugin from "./tools/remark-code-quote";
 import rehypeHeadingSpan from "./tools/rehype-heading-span";
 import rehypeLineNumbers from "./tools/rehype-line-numbers";
+import rehypeCodeCopyButton from "./tools/rehype-code-copy-button";
 import remarkAside from "./tools/remark-aside";
 
 import compressor from "astro-compressor";
@@ -46,7 +47,7 @@ export default defineConfig({
 			footnoteLabel: " ",
 		},
 		remarkPlugins: [remarkAside, codeBlockPlugin, remarkBreaks],
-		rehypePlugins: [rehypeLineNumbers, rehypeHeadingSpan],
+		rehypePlugins: [rehypeLineNumbers, rehypeHeadingSpan, rehypeCodeCopyButton],
 		shikiConfig: {
 			defaultColor: false,
 			themes: {

--- a/src/layouts/BlogBase.astro
+++ b/src/layouts/BlogBase.astro
@@ -3,6 +3,7 @@ import Base from "./Base.astro";
 import { SITE_TITLE } from "../config";
 
 import "../styles/blog.css";
+import "../styles/code-copy-button.css";
 const { post } = Astro.props;
 const { title, pubDate, tags } = post.data;
 const formattedDate = pubDate.toLocaleDateString("ja-JP", {
@@ -80,3 +81,26 @@ const formattedDate = pubDate.toLocaleDateString("ja-JP", {
 		margin-bottom: 0;
 	}
 </style>
+
+<script>
+	document.addEventListener("DOMContentLoaded", () => {
+		document.querySelectorAll(".copy-button").forEach(button => {
+			button.addEventListener("click", () => {
+				const pre = button.closest("pre");
+				const code = pre.querySelector("code").innerText;
+				
+				navigator.clipboard.writeText(code).then(() => {
+					button.textContent = button.dataset.successText;
+					button.classList.add("copied");
+					
+					setTimeout(() => {
+						button.textContent = button.dataset.copyText;
+						button.classList.remove("copied");
+					}, parseInt(button.dataset.successDuration, 10) || 2000);
+				}).catch(err => {
+					console.error("Could not copy text: ", err);
+				});
+			});
+		});
+	});
+</script>

--- a/src/styles/code-copy-button.css
+++ b/src/styles/code-copy-button.css
@@ -1,0 +1,38 @@
+.code-block-with-copy {
+  position: relative;
+}
+
+.copy-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  background: rgba(var(--accent2-rgb, 106, 153, 78), 0.15);
+  color: var(--color);
+  border: 1px solid rgba(var(--accent1-rgb, 46, 77, 23), 0.2);
+  border-radius: 4px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s, background-color 0.2s;
+}
+
+.code-block-with-copy:hover .copy-button {
+  opacity: 1;
+}
+
+.copy-button.copied {
+  background: rgba(var(--accent2-rgb, 106, 153, 78), 0.4);
+  color: var(--color);
+}
+
+/* Add RGB values for colors to enable alpha transparency */
+:root {
+  --accent1-rgb: 46, 77, 23;
+  --accent2-rgb: 106, 153, 78;
+}
+
+.dark {
+  --accent1-rgb: 241, 244, 224;
+  --accent2-rgb: 139, 195, 74;
+}

--- a/tools/rehype-code-copy-button/index.js
+++ b/tools/rehype-code-copy-button/index.js
@@ -1,0 +1,163 @@
+import { visit } from "unist-util-visit";
+import { toString } from "hast-util-to-string";
+
+/**
+ * Rehypeプラグイン: コードブロックにコピーボタンを追加
+ * @param {object} options - プラグインのオプション
+ * @param {string} options.buttonClassName - コピーボタン用のCSSクラス名 (デフォルト: 'copy-button')
+ * @param {string} options.buttonText - コピーボタンのテキスト (デフォルト: 'Copy')
+ * @param {string} options.buttonSuccessText - コピー成功時のテキスト (デフォルト: 'Copied!')
+ * @param {number} options.successDuration - 成功メッセージの表示時間(ms) (デフォルト: 2000)
+ * @returns {function} Unified/Rehypeトランスフォーマー
+ */
+export default function rehypeCodeCopyButton(options = {}) {
+  const {
+    buttonClassName = "copy-button",
+    buttonText = "Copy",
+    buttonSuccessText = "Copied!",
+    successDuration = 2000,
+  } = options;
+
+  return (tree) => {
+    visit(tree, "element", (node) => {
+      // pre > code のパターンを探す
+      if (node.tagName !== "pre" || !node.children?.[0]?.tagName === "code") {
+        return;
+      }
+
+      // すでにラップされている場合はスキップ
+      if (node.properties?.className?.includes("code-block-wrapper")) {
+        return;
+      }
+
+      // const codeNode = node.children[0];
+      
+      // コードのテキストを取得
+      // const code = toString(codeNode);
+
+      // 相対的な位置指定のために親要素をposition: relativeに
+      node.properties = node.properties || {};
+      node.properties.className = node.properties.className || [];
+      if (!Array.isArray(node.properties.className)) {
+        node.properties.className = [node.properties.className];
+      }
+      node.properties.className.push("code-block-with-copy");
+
+      // コピーボタンを作成
+      const copyButton = {
+        type: "element",
+        tagName: "button",
+        properties: {
+          className: [buttonClassName],
+          "aria-label": "コードをクリップボードにコピー",
+          "data-copy-text": buttonText,
+          "data-success-text": buttonSuccessText,
+          "data-success-duration": successDuration,
+          onClick: {
+            type: "raw",
+            value: `(function() {
+              const button = this;
+              const pre = button.closest("pre");
+              const code = pre.querySelector("code").innerText;
+              
+              navigator.clipboard.writeText(code).then(() => {
+                button.textContent = button.dataset.successText;
+                button.classList.add("copied");
+                
+                setTimeout(() => {
+                  button.textContent = button.dataset.copyText;
+                  button.classList.remove("copied");
+                }, parseInt(button.dataset.successDuration, 10));
+              }).catch((err) => {
+                console.error("Could not copy text: ", err);
+              });
+            })()`,
+          },
+        },
+        children: [
+          {
+            type: "text",
+            value: buttonText,
+          },
+        ],
+      };
+
+      // ボタンをpre要素に追加
+      node.children.push(copyButton);
+    });
+
+    // インラインスクリプトを追加
+    // コピー機能のためのスクリプトを追加
+    const inlineScript = {
+      type: "element",
+      tagName: "script",
+      properties: {},
+      children: [
+        {
+          type: "text",
+          value: `
+          document.addEventListener("DOMContentLoaded", () => {
+            document.querySelectorAll(".${buttonClassName}").forEach(button => {
+              button.addEventListener("click", () => {
+                const pre = button.closest("pre");
+                const code = pre.querySelector("code").innerText;
+                
+                navigator.clipboard.writeText(code).then(() => {
+                  button.textContent = button.dataset.successText;
+                  button.classList.add("copied");
+                  
+                  setTimeout(() => {
+                    button.textContent = button.dataset.copyText;
+                    button.classList.remove("copied");
+                  }, parseInt(button.dataset.successDuration, 10));
+                }).catch(err => {
+                  console.error("Could not copy text: ", err);
+                });
+              });
+            });
+          });
+          `,
+        },
+      ],
+    };
+
+    // body要素にスクリプトを追加
+    // ただし、AstroではこのスクリプトはCSSとともにレイアウトコンポーネントに含めるべき
+    // このコメントはその助言を記載
+    tree.children.push({
+      type: "comment",
+      value: ` 
+      Note: For Astro integration, add this CSS to your styles:
+      
+      .code-block-with-copy {
+        position: relative;
+      }
+      
+      .copy-button {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        padding: 0.25rem 0.5rem;
+        background: rgba(0, 0, 0, 0.1);
+        border: none;
+        border-radius: 4px;
+        font-size: 0.8rem;
+        cursor: pointer;
+        opacity: 0;
+        transition: opacity 0.2s;
+      }
+      
+      .code-block-with-copy:hover .copy-button {
+        opacity: 1;
+      }
+      
+      .copy-button.copied {
+        background: #4caf50;
+        color: white;
+      }
+      `,
+    });
+    
+    // tree.children.push(inlineScript);
+  };
+}


### PR DESCRIPTION
## 概要
- rehypeプラグインを作成してコードブロックにコピーボタンを追加しました
- コードをクリップボードにコピーする機能を実装
- コピー成功時の視覚的フィードバックを表示
- ダークモード対応のスタイリング

## 変更内容
- `rehype-code-copy-button` プラグインの作成
- コードブロックの右上にホバー時表示されるコピーボタンを追加
- クリップボードAPI を使用してコード内容をコピー
- ボタンのスタイリングをテーマに合わせて調整

## テスト方法
1. 開発サーバーを起動 (`pnpm dev`)
2. ブログ記事のコードブロックにマウスオーバー
3. 表示されるコピーボタンをクリック
4. クリップボードにコードがコピーされ、ボタンの表示が変わることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)