### PR TITLE
目次（TOC）機能の追加

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,7 @@ import codeBlockPlugin from "./tools/remark-code-quote";
 import rehypeHeadingSpan from "./tools/rehype-heading-span";
 import rehypeLineNumbers from "./tools/rehype-line-numbers";
 import rehypeCodeCopyButton from "./tools/rehype-code-copy-button";
+import rehypeToc from "./tools/rehype-toc";
 import remarkAside from "./tools/remark-aside";
 
 import compressor from "astro-compressor";
@@ -47,7 +48,24 @@ export default defineConfig({
 			footnoteLabel: " ",
 		},
 		remarkPlugins: [remarkAside, codeBlockPlugin, remarkBreaks],
-		rehypePlugins: [rehypeLineNumbers, rehypeHeadingSpan, rehypeCodeCopyButton],
+		rehypePlugins: [
+				rehypeLineNumbers, 
+				rehypeHeadingSpan, 
+				rehypeCodeCopyButton,
+				[rehypeToc, {
+					headings: ["h2", "h3"],
+					className: "toc",
+					title: "目次",
+					titleClassName: "toc-title",
+					listClassName: "toc-list",
+					listItemClassName: "toc-item",
+					linkClassName: "toc-link",
+					collapsible: true,
+					defaultOpen: false,
+					splitView: true,
+					pcClassName: "toc-pc",
+				}]
+			],
 		shikiConfig: {
 			defaultColor: false,
 			themes: {

--- a/src/layouts/BlogBase.astro
+++ b/src/layouts/BlogBase.astro
@@ -84,6 +84,7 @@ const formattedDate = pubDate.toLocaleDateString("ja-JP", {
 
 <script>
 	document.addEventListener("DOMContentLoaded", () => {
+		// コードコピーボタンの設定
 		document.querySelectorAll(".copy-button").forEach(button => {
 			button.addEventListener("click", () => {
 				const pre = button.closest("pre");
@@ -102,5 +103,103 @@ const formattedDate = pubDate.toLocaleDateString("ja-JP", {
 				});
 			});
 		});
+
+		// 目次の現在位置の強調表示（モバイル版とPC版両方）
+		const tocLinks = document.querySelectorAll('.toc-link');
+		
+		// 目次リンクに対応する見出し要素だけを取得する（リンクのhrefから対象を特定）
+		const headingIds = Array.from(tocLinks).map(link => {
+			const href = link.getAttribute('href');
+			return href && href.startsWith('#') ? href.substring(1) : null;
+		}).filter(Boolean);
+		
+		const headings = Array.from(document.querySelectorAll('h2, h3')).filter(heading => 
+			heading.id && headingIds.includes(heading.id)
+		);
+		
+		// 見出しが存在しない場合は処理を終了
+		if (headings.length === 0 || tocLinks.length === 0) return;
+		
+		// 目次リンクとIDをマップ
+		const idToTocLink = new Map();
+		tocLinks.forEach(link => {
+			const href = link.getAttribute('href');
+			if (href && href.startsWith('#')) {
+				const id = href.substring(1);
+				idToTocLink.set(id, link);
+			}
+		});
+		
+		// 現在アクティブな見出しを追跡するための変数
+		let currentActiveHeading = null;
+		
+		// 見出し要素をスクロール位置に基づいて評価する関数
+		function evaluateHeadings() {
+			// 画面に表示されている見出しを収集
+			const visibleHeadings = [];
+			
+			headings.forEach(heading => {
+				const rect = heading.getBoundingClientRect();
+				const topVisible = rect.top > 0 && rect.top < window.innerHeight * 0.5;
+				const elementInView = rect.top >= 0 && rect.bottom <= window.innerHeight;
+				const partiallyVisible = rect.top < window.innerHeight && rect.bottom > 0;
+				
+				if (topVisible || elementInView || partiallyVisible) {
+					visibleHeadings.push({
+						id: heading.id,
+						y: rect.top,
+						element: heading
+					});
+				}
+			});
+			
+			// 可視範囲内の見出しがあれば、最も上にある見出しをアクティブにする
+			if (visibleHeadings.length > 0) {
+				// 上から順に並べる
+				visibleHeadings.sort((a, b) => a.y - b.y);
+				const topHeading = visibleHeadings[0];
+				
+				// 同じ見出しが既にアクティブなら何もしない
+				if (currentActiveHeading !== topHeading.id) {
+					// 古いアクティブ状態をクリア
+					document.querySelectorAll('.toc-link-active').forEach(el => {
+						el.classList.remove('toc-link-active');
+					});
+					
+					// 新しくアクティブにする（モバイル版とPC版の両方）
+					// 同じIDのリンクを全て取得（モバイル版とPC版の両方）
+					const allTocLinksWithSameId = document.querySelectorAll(`.toc-link[href="#${topHeading.id}"]`);
+					
+					if (allTocLinksWithSameId.length > 0) {
+						// 全てのリンクをアクティブにする
+						allTocLinksWithSameId.forEach(link => {
+							link.classList.add('toc-link-active');
+						});
+						
+						currentActiveHeading = topHeading.id;
+						
+						// PC版目次がスクロール領域内なら、アクティブな項目を表示範囲内にスクロール
+						const pcTocContainer = document.querySelector('.toc.toc-pc');
+						if (pcTocContainer && window.innerWidth >= 1024) {
+							const pcTocLink = pcTocContainer.querySelector(`.toc-link[href="#${topHeading.id}"]`);
+							if (pcTocLink) {
+								const activeLinkRect = pcTocLink.getBoundingClientRect();
+								const tocRect = pcTocContainer.getBoundingClientRect();
+								
+								if (activeLinkRect.bottom > tocRect.bottom || activeLinkRect.top < tocRect.top) {
+									pcTocLink.scrollIntoView({ behavior: 'smooth', block: 'center' });
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		// スクロールイベントリスナーを追加
+		window.addEventListener('scroll', evaluateHeadings, { passive: true });
+		
+		// 初期状態を評価
+		evaluateHeadings();
 	});
 </script>

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -17,6 +17,130 @@ article.blog {
 	li::marker {
 		color: var(--gray);
 	}
+	
+	/* 目次スタイル - 共通 */
+	.toc {
+		background: rgba(90, 137, 67, 0.05);
+		border-radius: 4px;
+		padding: var(--space-xs);
+		margin: var(--space-s) 0;
+		border-left: 2px solid var(--accent2);
+	}
+	
+	.toc-details {
+		width: 100%;
+	}
+	
+	.toc-title {
+		margin-top: 0 !important;
+		font-size: 1rem;
+		border-bottom: none !important;
+		cursor: pointer;
+		padding: 0;
+		font-weight: normal;
+		color: var(--gray);
+		
+		&::marker {
+			color: var(--accent2);
+		}
+		
+		&::-webkit-details-marker {
+			color: var(--accent2);
+		}
+		
+		&:hover {
+			color: var(--accent3);
+		}
+	}
+	
+	.toc-list {
+		list-style-type: none;
+		padding-left: 0;
+		margin: var(--space-xs) 0 0 0;
+		font-size: 0.9rem;
+	}
+	
+	.toc-item {
+		margin: 0.25rem 0;
+		line-height: 1.3;
+	}
+	
+	.toc-item.depth-2 {
+		margin-left: 0;
+	}
+	
+	.toc-item.depth-3 {
+		margin-left: 0.75rem;
+		font-size: 0.85rem;
+		opacity: 0.9;
+	}
+	
+	.toc-link {
+		display: inline-block;
+		text-decoration: none;
+		color: var(--text-primary);
+		padding: 0.1rem 0.3rem;
+		border-radius: 3px;
+		transition: all 0.2s ease;
+		
+		&:hover {
+			text-decoration: underline;
+			color: var(--accent2);
+		}
+	}
+	
+	.toc-link-active {
+		background-color: rgba(90, 137, 67, 0.15);
+		color: var(--accent2);
+		font-weight: 500;
+		position: relative;
+		
+		&::before {
+			content: "";
+			position: absolute;
+			left: -0.5rem;
+			top: 50%;
+			transform: translateY(-50%);
+			width: 3px;
+			height: 70%;
+			background-color: var(--accent2);
+			border-radius: 2px;
+		}
+	}
+	
+	/* モバイル用目次 */
+	.toc.toc-mobile {
+		display: block;
+	}
+	
+	/* PC用目次（右側固定） */
+	.toc.toc-pc {
+		display: none;
+	}
+	
+	/* メディアクエリ */
+	@media (min-width: 1024px) {
+		/* モバイル用目次を非表示 */
+		.toc.toc-mobile {
+			display: none;
+		}
+		
+		/* PC用目次を表示 */
+		.toc.toc-pc {
+			display: block;
+			position: fixed;
+			top: 5rem;
+			right: 1rem;
+			width: 16rem;
+			max-height: calc(100vh - 10rem);
+			overflow-y: auto;
+			margin: 0;
+			z-index: 10;
+			background: var(--bg);
+			border: 1px solid rgba(90, 137, 67, 0.2);
+			box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+		}
+	}
 
 	/* ヘッダー */
 	h1,
@@ -402,6 +526,12 @@ body.dark article.blog {
 		&.note {
 			background: rgba(122, 179, 61, 0.1);
 		}
+	}
+	
+	/* 目次スタイル - ダークモード */
+	.toc {
+		background: rgba(160, 168, 164, 0.1);
+		border-left: 4px solid var(--accent2);
 	}
 
 	.code-block-wrapper {

--- a/tools/rehype-toc/index.js
+++ b/tools/rehype-toc/index.js
@@ -1,0 +1,183 @@
+import { visit } from "unist-util-visit";
+import { toString } from "hast-util-to-string";
+
+export default function rehypeToc(options = {}) {
+  const {
+    headings = ["h2", "h3"],
+    className = "toc",
+    title = "目次",
+    titleClassName = "toc-title",
+    listClassName = "toc-list",
+    listItemClassName = "toc-item",
+    linkClassName = "toc-link",
+    collapsible = true,
+    defaultOpen = true,
+    // PC用とモバイル用で分けるかどうか
+    splitView = true,
+    pcClassName = "toc-pc",
+  } = options;
+
+  return function transformer(tree) {
+    // 記事内の見出しを収集
+    const headingNodes = [];
+    visit(tree, "element", (node) => {
+      if (headings.includes(node.tagName)) {
+        const text = toString(node);
+        // 簡易的なスラッグ生成（日本語対応）
+        let id = node.properties.id || createSlug(text);
+        
+        // 見出しにIDがなければ追加、または同名IDがある場合は重複を避ける
+        if (!node.properties.id) {
+          // 同名の見出しに対して一意のIDを生成する
+          let uniqueId = id;
+          let counter = 1;
+          while (headingNodes.some(h => h.id === uniqueId)) {
+            uniqueId = `${id}-${counter}`;
+            counter++;
+          }
+          node.properties.id = uniqueId;
+          id = uniqueId;
+        }
+        
+        headingNodes.push({
+          tagName: node.tagName,
+          text,
+          id,
+        });
+      }
+    });
+
+    // 見出しがなければTOCを作成しない
+    if (headingNodes.length === 0) {
+      return;
+    }
+
+    // TOCアイテムの生成関数
+    function createTocItems() {
+      return headingNodes.map((heading) => {
+        const link = {
+          type: "element",
+          tagName: "a",
+          properties: { 
+            class: linkClassName, 
+            href: `#${heading.id}` 
+          },
+          children: [{ type: "text", value: heading.text }]
+        };
+        
+        return {
+          type: "element",
+          tagName: "li",
+          properties: { 
+            class: `${listItemClassName} depth-${heading.tagName.substring(1)}`
+          },
+          children: [link]
+        };
+      });
+    }
+
+    // TOCコンポーネントの生成関数
+    function createTocComponent(additionalClassName = '', isPC = false) {
+      const tocItems = createTocItems();
+      
+      const tocList = {
+        type: "element",
+        tagName: "ul",
+        properties: { class: listClassName },
+        children: tocItems
+      };
+      
+      // 折りたたみ機能をつける場合はdetails/summaryを使用
+      let tocComponent;
+      if (collapsible) {
+        const tocSummary = {
+          type: "element",
+          tagName: "summary",
+          properties: { class: titleClassName },
+          children: [{ type: "text", value: title }]
+        };
+        
+        const tocDetails = {
+          type: "element",
+          tagName: "details",
+          properties: { 
+            class: `${className}-details`,
+            open: isPC ? true : defaultOpen ? "open" : null // PC版は常に開く
+          },
+          children: [tocSummary, tocList]
+        };
+        
+        tocComponent = {
+          type: "element",
+          tagName: "div",
+          properties: { 
+            class: additionalClassName ? `${className} ${additionalClassName}` : className
+          },
+          children: [tocDetails]
+        };
+      } else {
+        const tocTitle = {
+          type: "element",
+          tagName: "h2",
+          properties: { class: titleClassName },
+          children: [{ type: "text", value: title }]
+        };
+        
+        tocComponent = {
+          type: "element",
+          tagName: "div",
+          properties: { 
+            class: additionalClassName ? `${className} ${additionalClassName}` : className
+          },
+          children: [tocTitle, tocList]
+        };
+      }
+      
+      return tocComponent;
+    }
+    
+    // モバイル用とPC用のTOCを作成
+    const mobileTocContainer = createTocComponent('toc-mobile');
+    const pcTocContainer = createTocComponent(pcClassName, true);
+
+    // モバイル用TOCを最初のh1またはh2の前に挿入
+    let mobileTocInserted = false;
+    visit(tree, "element", (node, index, parent) => {
+      if (!mobileTocInserted && (node.tagName === "h1" || node.tagName === "h2")) {
+        parent.children.splice(index, 0, mobileTocContainer);
+        mobileTocInserted = true;
+        return [visit.SKIP, index + 1];
+      }
+    });
+
+    // 見出しが見つからなかった場合は、最初の段落の前に挿入
+    if (!mobileTocInserted) {
+      visit(tree, "element", (node, index, parent) => {
+        if (!mobileTocInserted && node.tagName === "p") {
+          parent.children.splice(index, 0, mobileTocContainer);
+          mobileTocInserted = true;
+          return [visit.SKIP, index + 1];
+        }
+      });
+    }
+
+    // それでも挿入できなかった場合は、ツリーの先頭に挿入
+    if (!mobileTocInserted && tree.children && tree.children.length > 0) {
+      tree.children.unshift(mobileTocContainer);
+    }
+    
+    // PC用TOCをツリーの最後に追加
+    if (tree.children && tree.children.length > 0) {
+      tree.children.push(pcTocContainer);
+    }
+  };
+}
+
+// 簡易的なスラッグ生成関数
+function createSlug(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\p{L}\p{N}]/gu, "-") // 英数字と日本語文字以外をハイフンに
+    .replace(/-+/g, "-") // 連続するハイフンを一つに
+    .replace(/^-|-$/g, ""); // 先頭と末尾のハイフンを削除
+}


### PR DESCRIPTION
## 概要
- rehype-tocプラグインを実装して記事に目次を自動生成
- PC表示とモバイル表示で別々のUIを提供
  - モバイル: 記事上部に折りたたみ可能な目次
  - PC: 右サイドバーに固定表示される目次
- スクロール位置に応じて現在読んでいる見出しをハイライト
- 同名見出しにも対応（一意のID生成）

## テスト方法
1. ブログ記事を開く
2. モバイル表示で目次の開閉ができることを確認
3. PC表示で右側に固定表示されることを確認
4. スクロールすると現在の見出しがハイライトされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)